### PR TITLE
Centralizing the layout and add some placeholders

### DIFF
--- a/connexion/Login.html
+++ b/connexion/Login.html
@@ -20,7 +20,7 @@
             Welcome Back! <br />
             <span style="color: hsl(218, 81%, 75%)">Log in to your account</span>
           </h1>
-          <p class="mb-4 opacity-70 text-white">
+          <p class="mb-4 opacity-70" style="color: hsl(218, 81%, 85%)">
             Enter your credentials to access your account and explore amazing features.
           </p>
         </div>

--- a/connexion/Login.html
+++ b/connexion/Login.html
@@ -10,11 +10,11 @@
   <link rel="stylesheet" href="../assets/CSS/bootstrap.min.css">
 </head>
 
-<body class="background-radial-gradient">
+<body class="h-100 w-100 d-flex flex-column align-items-center justify-content-center background-radial-gradient">
   <!-- Section: Login Block -->
-  <section class="overflow-hidden">
+  <section class="w-100 overflow-hidden">
     <div class="container px-4 py-5 px-md-5 text-center text-lg-start my-5">
-      <div class="row gx-lg-5 align-items-center mb-5">
+      <div class="row gx-lg-5 align-items-center">
         <div class="col-lg-6 mb-5 mb-lg-0" style="z-index: 10">
           <h1 class="my-5 display-5 fw-bold ls-tight text-white">
             Welcome Back! <br />
@@ -34,14 +34,14 @@
               <form>
                 <!-- Email input -->
                 <div class="form-outline mb-4">
-                  <input type="email" id="email" class="form-control" required />
                   <label class="form-label" for="email">Email address</label>
+                  <input type="email" id="email" class="form-control" required placeholder="example@example.com" />
                 </div>
 
                 <!-- Password input -->
                 <div class="form-outline mb-4">
-                  <input type="password" id="password" class="form-control" required />
                   <label class="form-label" for="password">Password</label>
+                  <input type="password" id="password" class="form-control" required placeholder="**********" />
                 </div>
 
                 <!-- Remember Me Checkbox -->
@@ -81,6 +81,7 @@
       </div>
     </div>
   </section>
+  <!-- Section: Login Block -->
   <script src="../assets/icons/all.min.js"></script>
 </body>
 

--- a/connexion/Signup.html
+++ b/connexion/Signup.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="../assets/CSS/style.css">
 </head>
 
-<body class="background-radial-gradient">
+<body class="h-100 w-100 d-flex flex-column align-items-center justify-content-center background-radial-gradient">
   <!-- Section: Design Block -->
-  <section class="overflow-hidden">
+  <section class="w-100 overflow-hidden">
     <div class="container px-4 py-5 px-md-5 text-center text-lg-start my-5">
-      <div class="row gx-lg-5 align-items-center mb-5">
+      <div class="row gx-lg-5 align-items-center">
         <div class="col-lg-6 mb-5 mb-lg-0" style="z-index: 10">
           <h1 class="my-5 display-5 fw-bold ls-tight" style="color: hsl(218, 81%, 95%)">
             The best offer <br />
@@ -39,13 +39,13 @@
                   <div class="col-md-6 mb-4">
                     <div data-mdb-input-init class="form-outline">
                       <label class="form-label" for="form3Example1">First name</label>
-                      <input type="text" id="form3Example1" class="form-control" />
+                      <input type="text" id="form3Example1" class="form-control" placeholder="John" />
                     </div>
                   </div>
                   <div class="col-md-6 mb-4">
                     <div data-mdb-input-init class="form-outline">
                       <label class="form-label" for="form3Example2">Last name</label>
-                      <input type="text" id="form3Example2" class="form-control" />
+                      <input type="text" id="form3Example2" class="form-control" placeholder="Doe" />
                     </div>
                   </div>
                 </div>
@@ -53,14 +53,14 @@
                 <!-- Email input -->
                 <div data-mdb-input-init class="form-outline mb-4">
                   <label class="form-label" for="form3Example3">Email address</label>
-                  <input type="email" id="form3Example3" class="form-control" />
+                  <input type="email" id="form3Example3" class="form-control" placeholder="example@example.com" />
 
                 </div>
 
                 <!-- Password input -->
                 <div data-mdb-input-init class="form-outline mb-4">
                   <label class="form-label" for="form3Example4">Password</label>
-                  <input type="password" id="form3Example4" class="form-control" />
+                  <input type="password" id="form3Example4" class="form-control" placeholder="**********" />
 
                 </div>
 


### PR DESCRIPTION
### **Description**
This pull request aims to improve the layout and design of the authentication screens. The key enhancements include:

- Centralizing the layout of both the login and sign-up pages.
- Adding placeholders to the input fields on the login and sign-up pages.

### **Before (sign-up page):**
![image](https://github.com/user-attachments/assets/05c58d3b-1928-4c5d-b2ae-29e4a6980819)
 
### **After (sign-up page):**
![image](https://github.com/user-attachments/assets/0b18c06f-46c4-4de0-a984-af85ebd32544)


### **Before (login page):**
![image](https://github.com/user-attachments/assets/4c124dbf-e5ad-4446-b0e6-707f9cef6210)

### **After (login page):**
![image](https://github.com/user-attachments/assets/3f55d2f8-647b-4e21-bb54-0f8d108a7ad2)
**Please note:** Screenshots were taken at 80% zoom to highlight the differences.
